### PR TITLE
Unify output formats

### DIFF
--- a/data_diff/__main__.py
+++ b/data_diff/__main__.py
@@ -259,17 +259,44 @@ def main(conf, run, **kw):
 
     try:
         if kw["dbt"]:
-            dbt_diff(
+            diff = dbt_diff(
                 profiles_dir_override=kw["dbt_profiles_dir"],
                 project_dir_override=kw["dbt_project_dir"],
                 is_cloud=kw["cloud"],
             )
+            render_diff(diff, kw["limit"], kw["stats"], kw["json_output"])
+
         else:
             return _data_diff(**kw)
     except Exception as e:
         logging.error(e)
         if kw["debug"]:
             raise
+
+
+def render_diff(diff_iter, limit, stats, json_output):
+    if limit:
+        assert not stats
+        diff_iter = islice(diff_iter, int(limit))
+
+    if stats:
+        if json_output:
+            rich.print(json.dumps(diff_iter.get_stats_dict()))
+        else:
+            rich.print(diff_iter.get_stats_string())
+
+    else:
+        for op, values in diff_iter:
+            color = COLOR_SCHEME[op]
+
+            if json_output:
+                jsonl = json.dumps([op, list(values)])
+                rich.print(f"[{color}]{jsonl}[/{color}]")
+            else:
+                text = f"{op} {', '.join(map(str, values))}"
+                rich.print(f"[{color}]{text}[/{color}]")
+
+            sys.stdout.flush()
 
 
 def _data_diff(
@@ -444,28 +471,7 @@ def _data_diff(
 
     diff_iter = differ.diff_tables(*segments)
 
-    if limit:
-        assert not stats
-        diff_iter = islice(diff_iter, int(limit))
-
-    if stats:
-        if json_output:
-            rich.print(json.dumps(diff_iter.get_stats_dict()))
-        else:
-            rich.print(diff_iter.get_stats_string())
-
-    else:
-        for op, values in diff_iter:
-            color = COLOR_SCHEME[op]
-
-            if json_output:
-                jsonl = json.dumps([op, list(values)])
-                rich.print(f"[{color}]{jsonl}[/{color}]")
-            else:
-                text = f"{op} {', '.join(map(str, values))}"
-                rich.print(f"[{color}]{text}[/{color}]")
-
-            sys.stdout.flush()
+    render_diff(diff_iter, limit, stats, json_output)
 
     end = time.monotonic()
 

--- a/data_diff/dbt.py
+++ b/data_diff/dbt.py
@@ -73,7 +73,7 @@ def dbt_diff(
             )
 
         if not is_cloud and len(diff_vars.primary_keys) == 1:
-            _local_diff(diff_vars)
+            return _local_diff(diff_vars)
         elif not is_cloud:
             rich.print(
                 "[red]"
@@ -152,28 +152,7 @@ def _local_diff(diff_vars: DiffVars) -> None:
     extra_columns = tuple(mutual_set)
 
     diff = diff_tables(table1, table2, threaded=True, algorithm=Algorithm.JOINDIFF, extra_columns=extra_columns)
-
-    if list(diff):
-        rich.print(
-            "[red]"
-            + dev_qualified_string
-            + " <> "
-            + prod_qualified_string
-            + "[/] \n"
-            + column_diffs_str
-            + diff.get_stats_string()
-            + "\n"
-        )
-    else:
-        rich.print(
-            "[red]"
-            + dev_qualified_string
-            + " <> "
-            + prod_qualified_string
-            + "[/] \n"
-            + column_diffs_str
-            + "[green]No row differences[/] \n"
-        )
+    return diff
 
 
 def _cloud_diff(diff_vars: DiffVars) -> None:


### PR DESCRIPTION
As a follow-up to https://github.com/dbeatty10/data-diff/pull/2, make all 3 of the pre-existing format options available when using `--dbt`.

## Usage
Usage for `--dbt` mode:

### Default
```shell
$ data-diff --dbt
```

```
Found 1 successful model runs from the last dbt command.
- 1, black
+ 1, orange
```

<img width="408" alt="image" src="https://user-images.githubusercontent.com/44704949/221060154-a7cc0527-815b-4c24-b1f9-70e46b28d08b.png">


### JSON
```shell
$ data-diff --dbt --json 
```

```shell
Found 1 successful model runs from the last dbt command.
["-", ["1", "black"]]
["+", ["1", "orange"]]
```

<img width="409" alt="image" src="https://user-images.githubusercontent.com/44704949/221060224-9c82809e-9bc4-494c-a4b8-11397d34c4fe.png">


### Stats
```shell
$ data-diff --dbt --stats
```

```shell
Found 1 successful model runs from the last dbt command.
2 rows in table A
2 rows in table B
0 rows exclusive to table A (not present in B)
0 rows exclusive to table B (not present in A)
1 rows updated
1 rows unchanged
50.00% difference score

Extra-Info:
  diff_counts = {'id_a': 0, 'color_a': 0}
  exclusive_count = 0
  table1_count = 2
  table2_count = 2
  validated_unique_keys = [['id'], ['id']]
```

<img width="418" alt="image" src="https://user-images.githubusercontent.com/44704949/221060091-b4fd337e-d583-42a8-80a1-f42b50c3d11a.png">
